### PR TITLE
Avoid downloading entire segments to memory

### DIFF
--- a/hlsclient/consumer.py
+++ b/hlsclient/consumer.py
@@ -4,6 +4,7 @@ import logging
 import urllib2
 import urlparse
 import m3u8
+import shutil
 
 import crypto
 
@@ -114,13 +115,12 @@ def download_to_file(uri, destination_path, current_key=None, new_key=False):
     filename = os.path.join(destination_path, os.path.basename(uri))
     if not os.path.exists(filename):
         logging.debug("Downloading {url}".format(url=uri))
-        request = urllib2.urlopen(url=uri)
-        raw = request.read()
+        raw = urllib2.urlopen(url=uri)
         if new_key is not False:
-            plain = crypto.decrypt(raw, current_key) if current_key else raw
-            raw = crypto.encrypt(plain, new_key) if new_key else plain
+            plain = crypto.Decrypt(raw, current_key) if current_key else raw
+            raw = crypto.Encrypt(plain, new_key) if new_key else plain
         with open(filename, 'wb') as f:
-            f.write(raw)
+            shutil.copyfileobj(raw, f)
         return filename
     else:
         # change modification time so the file is not removed by hlsclient.cleaner.clean

--- a/hlsclient/pkcs7.py
+++ b/hlsclient/pkcs7.py
@@ -16,13 +16,13 @@ class PKCS7Encoder():
                     'and 99')
         self.block_size = block_size
 
-    def encode(self, text):
-        text_length = len(text)
+    def get_padding(self, text_length):
         amount_to_pad = self.block_size - (text_length % self.block_size)
-        if amount_to_pad == 0:
-            amount_to_pad = self.block_size
         pad = unhexlify('%02d' % amount_to_pad)
-        return text + pad * amount_to_pad
+        return pad * amount_to_pad
+
+    def encode(self, text):
+        return text + self.get_padding(len(text))
 
     def decode(self, text):
         pad = int(hexlify(text[-1]))

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import urllib
 import os
 import m3u8
+import StringIO
 from m3u8.model import Segment, Key
 
 import hlsclient.consumer
@@ -81,6 +82,22 @@ def test_consumer_should_be_able_to_encrypt_and_decrypt_content(tmpdir):
     content = "blabla"
     fake_key = crypto.get_key("fake_key.bin", str(tmpdir))
     assert content == crypto.decrypt(crypto.encrypt(content, fake_key), fake_key)
+
+    # Generate some big data and try it out
+    bigcontent = content * 2 * 1024 + content
+    bigcontent = '0123456789abcdef'
+
+    contentf = StringIO.StringIO(bigcontent)
+    encryptf = crypto.Encrypt(contentf, fake_key)
+    decryptf = crypto.Decrypt(encryptf, fake_key)
+
+    decrypted = ''
+    data = decryptf.read(1024)
+    while data:
+        decrypted += data
+        data = decryptf.read(1024)
+
+    assert bigcontent == decrypted
 
 def test_key_generated_by_consumer_should_be_saved_on_right_path(tmpdir):
     fake_key = crypto.get_key("fake_key.bin", str(tmpdir))


### PR DESCRIPTION
Currently chunks are downloaded to memory and written to disk. When you are downloading a large number of HD m3u8 streamins in parallel, this can lead to a memory crunch. By using file objects and making use of AES cipher's ability to encrypt/decrypt in chunks, we can reduce this memory utilization.

To do this, two classes Encrypt and Decrypt have been created in crypto.py, which are subclassed from StringIO. This handles the chunked (in multiple of 16 bytes) encryption and decryption.

In consumer.py, shutil.copyfileobj is used to copy the contents from the urllib2 request object.

In pkcs7.py, the statement
`amount_to_pad = self.block_size - (text_length % self.block_size)`

will never result in amount_to_pad = 0, so the next lines are not necessary

`if amount_to_pad == 0:
    amount_to_pad = self.block_size`
